### PR TITLE
add dataclasses import

### DIFF
--- a/chop/constraints.py
+++ b/chop/constraints.py
@@ -11,7 +11,7 @@ Part of this code is adapted from https://github.com/ZIB-IOL."""
 from copy import deepcopy
 from collections import defaultdict
 import warnings
-
+import dataclasses
 import torch
 
 import numpy as np


### PR DESCRIPTION
PR #72 added a `@dataclasses.dataclass` decorator, but the `import dataclasses` was missing in the constraints file.